### PR TITLE
feature: Wikilink CLI converter (ContextUP)

### DIFF
--- a/docs/feature-wikilink-cli.md
+++ b/docs/feature-wikilink-cli.md
@@ -1,0 +1,14 @@
+# Feature: Wikilink CLI Converter (ContextUP)
+
+Motivation:
+Provide a small utility to convert Obsidian-style wikilinks [[Note|Alias]] into standard markdown links. Useful for exports and interoperability.
+
+Change summary:
+- Added scripts/convert-wikilinks.mjs: a small CLI that converts wikilinks in a markdown file to standard markdown links.
+
+Test steps:
+- Run: node scripts/convert-wikilinks.mjs path/to/file.md
+- Verify wikilinks are converted.
+
+Risk assessment:
+- Low risk: only modifies files explicitly provided by the user. No infra/CI/deploy changes.

--- a/scripts/convert-wikilinks.mjs
+++ b/scripts/convert-wikilinks.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import fs from "node:fs"
+import path from "node:path"
+import ts from "typescript"
+
+function loadTsModule(modulePath) {
+  const sourcePath = path.resolve(modulePath)
+  const source = fs.readFileSync(sourcePath, "utf8")
+
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+    },
+    fileName: path.basename(modulePath),
+  })
+
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(outputText, "utf8").toString("base64")}`
+  return import(dataUrl)
+}
+
+async function main(){
+  const args = process.argv.slice(2)
+  if(args.length === 0){
+    console.error("Usage: convert-wikilinks <file.md>")
+    process.exit(2)
+  }
+  const file = args[0]
+  const mod = await loadTsModule("src/wikilinks.ts")
+  const input = fs.readFileSync(file, "utf8")
+  const out = input.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (m,t,a)=>{
+    const target = t.trim()
+    const text = (a||t).trim()
+    const rel = mod.targetToRelPath ? mod.targetToRelPath(target) : (target + ".md")
+    return `[${text}](${rel})`
+  })
+  fs.writeFileSync(file, out, "utf8")
+  console.log("Converted", file)
+}
+
+main().catch(e=>{console.error(e); process.exit(1)})


### PR DESCRIPTION
Motivation:\nProvide a small utility to convert Obsidian-style wikilinks [[Note|Alias]] into standard markdown links for exports and interoperability.\n\nCompetitor inspiration:\nObsidian MD uses wikilinks extensively; this tool helps users convert those to standard markdown during export/workflows.\n\nChange summary:\n- Added scripts/convert-wikilinks.mjs: CLI to convert wikilinks in a markdown file to standard markdown links.\n\nTest steps:\n1. Run: node scripts/convert-wikilinks.mjs path/to/file.md\n2. Verify wikilinks like [[Note|Alias]] and [[Note]] are converted to [Alias](Note.md) and [Note](Note.md).\n\nRisk assessment:\nLow risk — modifies only user-provided files; no infra/CI/deploy changes.\n