### PR TITLE
feature: add wikilink conversion script (ContextUP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,11 @@ Draglass is built with these principles:
 - **Minimal dependencies**: Only add what's necessary
 - **Small changes**: Prefer reviewable, incremental improvements
 - **Local-first**: User data stays local and private by default
+
+## Wikilink conversion CLI
+
+You can convert Obsidian-style wikilinks to standard Markdown using the included CLI:
+
+	npm run convert-wikilinks -- path/to/file.md
+
+See docs/feature-wikilink-cli.md for details.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint .",
     "test": "node scripts/test-wikilinks.mjs && node scripts/test-tags.mjs && node scripts/test-locked-sections.mjs && node scripts/test-tables.mjs && node scripts/test-templates.mjs && node scripts/test-daily-notes.mjs && node scripts/test-tasks.mjs",
     "test:locked-sections": "node scripts/test-locked-sections.mjs",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "convert-wikilinks": "node scripts/convert-wikilinks.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.0",


### PR DESCRIPTION
Motivation:
Provide a discoverable npm script and README instructions to run the existing wikilink conversion CLI. This increases usability without changing application code.

Competitor inspiration:
Obsidian MD provides small utilities and clear documentation; making the converter discoverable follows that UX pattern.

Change summary:
- Added package.json script convert-wikilinks to run scripts/convert-wikilinks.mjs
- Added README section with usage example

Test steps:
1. Run: npm run convert-wikilinks -- path/to/file.md
2. Verify that wikilinks like [[Note|Alias]] are converted to [Alias](Note.md)

Risk assessment:
Low risk: documentation and small script only. No infra/CI changes.
