### PR TITLE
fix: reveal correct task line when opening from Tasks panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1294,7 +1294,14 @@ function App() {
       setGraphViewOpen(false)
       const opened = await openNoteByRelPath(relPath)
       if (!opened) return
-      queueMicrotask(() => editorRef.current?.revealLine(lineNumber))
+
+      // Wait for the note switch render to commit before revealing the line.
+      // A microtask can run too early on first open, revealing in the previous doc.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          editorRef.current?.revealLine(lineNumber)
+        })
+      })
     },
     [openNoteByRelPath],
   )


### PR DESCRIPTION
## Summary
Fixes a timing bug when opening a task from the right sidebar Tasks panel.

When the target note was not already open, the line reveal could run before the editor finished switching documents, so it didn't scroll to the task line on first click.

## What changed
- In `onTaskClick`, replaced `queueMicrotask` reveal with a double `requestAnimationFrame` reveal.
- Added inline comment explaining why microtask timing is insufficient for first-open note switches.

## Result
- Clicking a task now opens the note and scrolls/highlights the intended line on the first click.

Closes #99
