### PR TITLE
feat: export current note as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "licenses:generate": "node scripts/generate-third-party-licenses.mjs",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "node scripts/test-wikilinks.mjs && node scripts/test-tags.mjs && node scripts/test-locked-sections.mjs && node scripts/test-tables.mjs && node scripts/test-templates.mjs && node scripts/test-daily-notes.mjs && node scripts/test-tasks.mjs &&  node scripts/test-export-pdf.mjs && node scripts/test-paste-images.mjs && node scripts/test-graph-interaction.mjs && node scripts/test-command-palette.mjs && node scripts/test-frontmatter-update.mjs",
+    "test": "node scripts/test-wikilinks.mjs && node scripts/test-tags.mjs && node scripts/test-locked-sections.mjs && node scripts/test-tables.mjs && node scripts/test-templates.mjs && node scripts/test-daily-notes.mjs && node scripts/test-tasks.mjs && node scripts/test-export-pdf.mjs && node scripts/test-export-html.mjs && node scripts/test-paste-images.mjs && node scripts/test-graph-interaction.mjs && node scripts/test-command-palette.mjs && node scripts/test-frontmatter-update.mjs",
     "test:locked-sections": "node scripts/test-locked-sections.mjs",
     "preview": "vite preview"
   },

--- a/scripts/test-export-html.mjs
+++ b/scripts/test-export-html.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import ts from 'typescript'
+
+const moduleCache = new Map()
+
+async function compileToDataUrl(modulePath) {
+  const sourcePath = path.resolve(modulePath)
+  const cached = moduleCache.get(sourcePath)
+  if (cached) return cached
+
+  const source = fs.readFileSync(sourcePath, 'utf8')
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+    },
+    fileName: path.basename(modulePath),
+  })
+
+  const importMatches = Array.from(outputText.matchAll(/from\s+['"](\.[^'"]+)['"]/g))
+  let rewritten = outputText
+
+  for (const match of importMatches) {
+    const rawSpecifier = match[1]
+    const baseDir = path.dirname(sourcePath)
+    const resolved = path.resolve(baseDir, `${rawSpecifier}.ts`)
+    const specifierDataUrl = await compileToDataUrl(resolved)
+    rewritten = rewritten.replace(
+      new RegExp(`from\\s+['"]${rawSpecifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`, 'g'),
+      `from '${specifierDataUrl}'`,
+    )
+  }
+
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(rewritten, 'utf8').toString('base64')}`
+  moduleCache.set(sourcePath, dataUrl)
+  return dataUrl
+}
+
+async function loadTsModule(modulePath) {
+  const dataUrl = await compileToDataUrl(modulePath)
+  return import(dataUrl)
+}
+
+const exportHtml = await loadTsModule('src/exportHtml.ts')
+
+const withTitleHtml = exportHtml.buildHtmlDocument('Hello <world>', {
+  title: 'My & Note',
+  includeTitle: true,
+})
+assert.equal(withTitleHtml.includes('<h1'), true)
+assert.equal(withTitleHtml.includes('My &amp; Note'), true)
+assert.equal(withTitleHtml.includes('Hello &lt;world&gt;'), true)
+
+const withoutTitleHtml = exportHtml.buildHtmlDocument('Body', {
+  title: 'Ignored',
+  includeTitle: false,
+})
+assert.equal(withoutTitleHtml.includes('<h1'), false)
+
+console.log('export-html: ok')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import { fileStem } from './path'
 import { buildDailyNoteRelPath, listExistingDailyNoteDates, resolveDailyNoteTemplatePath } from './dailyNotes'
 import { normalizeTag } from './tags'
 import { exportNoteAsPdf } from './exportPdf'
+import { exportNoteAsHtmlFile } from './exportHtml'
 
 const NoteEditor = lazy(() => import('./components/NoteEditor'))
 import { ExcalidrawEditor } from './components/ExcalidrawEditor'
@@ -1033,6 +1034,15 @@ function App() {
     await exportNoteAsPdf(noteText, { title: baseTitle, includeTitle }, () => printMainWindow())
   }, [activeRelPath, graphViewOpen, noteText, noteTitle])
 
+  const exportCurrentNoteAsHtml = useCallback(() => {
+    if (!activeRelPath || graphViewOpen) return
+    const baseTitle = noteTitle ?? fileStem(activeRelPath)
+
+    const includeTitle = window.confirm('Include the file name as an H1 title in the HTML export?')
+
+    exportNoteAsHtmlFile(noteText, { title: baseTitle, includeTitle })
+  }, [activeRelPath, graphViewOpen, noteText, noteTitle])
+
   const dailyTemplateRelPath = useMemo(
     () =>
       resolveDailyNoteTemplatePath(
@@ -1187,6 +1197,15 @@ function App() {
       },
     },
     {
+      id: 'export-note-as-html',
+      label: 'Export Note as HTML',
+      description: 'Export the current note as an HTML file',
+      enabled: !!activeRelPath && !graphViewOpen,
+      onExecute: () => {
+        exportCurrentNoteAsHtml()
+      },
+    },
+    {
       id: 'open-today-daily-note',
       label: "Open today's daily note",
       description: 'Open or create the note for today',
@@ -1287,7 +1306,7 @@ function App() {
         })()
       },
     },
-  ], [activeRelPath, createNewNote, deleteActiveNote, exportCurrentNoteAsPdf, graphViewOpen, hasLockedContent, isVaultUnlocked, loadVault, lockVault, noteTitle, onRequestUnlock, openChangePasswordModal, openInsertTemplatePicker, openNewNoteFromTemplatePicker, openTodayDailyNote, setError, settings.dailyNotesEnabled, vaultHasPassword, vaultPath])
+  ], [activeRelPath, createNewNote, deleteActiveNote, exportCurrentNoteAsHtml, exportCurrentNoteAsPdf, graphViewOpen, hasLockedContent, isVaultUnlocked, loadVault, lockVault, noteTitle, onRequestUnlock, openChangePasswordModal, openInsertTemplatePicker, openNewNoteFromTemplatePicker, openTodayDailyNote, setError, settings.dailyNotesEnabled, vaultHasPassword, vaultPath])
 
   const onTaskClick = useCallback(
     async (relPath: string, lineNumber: number) => {

--- a/src/exportHtml.ts
+++ b/src/exportHtml.ts
@@ -1,0 +1,66 @@
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+function sanitizeFileName(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return 'note'
+  return trimmed.replace(/[\\/:*?"<>|]/g, '-').slice(0, 120) || 'note'
+}
+
+export function buildHtmlDocument(noteText: string, options: { title: string; includeTitle: boolean }): string {
+  const heading = options.includeTitle
+    ? `<h1 style="margin: 0 0 24px; font-size: 32px; line-height: 1.2; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;">${escapeHtml(options.title)}</h1>`
+    : ''
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(options.title)}</title>
+  <style>
+    body {
+      margin: 32px;
+      color: #111827;
+      background: #ffffff;
+    }
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+  </style>
+</head>
+<body>
+  ${heading}
+  <pre>${escapeHtml(noteText)}</pre>
+</body>
+</html>`
+}
+
+export function exportNoteAsHtmlFile(
+  noteText: string,
+  options: { title: string; includeTitle: boolean },
+): void {
+  const html = buildHtmlDocument(noteText, options)
+  const blob = new Blob([html], { type: 'text/html;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = `${sanitizeFileName(options.title)}.html`
+  anchor.rel = 'noopener'
+  anchor.style.display = 'none'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary
Adds HTML export for the active note via Command Palette.

## What changed
- Added new `Export Note as HTML` command.
- Added HTML export utility (`src/exportHtml.ts`) that:
  - builds a complete standalone HTML document,
  - escapes note/title content for safe rendering,
  - downloads the result as `<note-title>.html`.
- Added a small unit-style test script (`scripts/test-export-html.mjs`) for document generation behavior.
- Included the new export test in the `npm test` pipeline.

## UX
- On export, user is asked whether to include the note title as an H1.
- Output is downloaded as an `.html` file and can be opened in browser or pasted/sent as needed.

Closes #97
