### PR TITLE
fix: reveal task line even when editor mounts after opening note

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -368,6 +368,7 @@ function App() {
   const [currentLockedRanges, setCurrentLockedRanges] = useState<LockedBodyRange[]>([])
   const [titleDraft, setTitleDraft] = useState('')
   const [titleEditing, setTitleEditing] = useState(false)
+  const pendingRevealLineRef = useRef<number | null>(null)
 
   const onRequestUnlock = useCallback(() => {
     if (!vaultPath) return
@@ -1294,10 +1295,27 @@ function App() {
       setGraphViewOpen(false)
       const opened = await openNoteByRelPath(relPath)
       if (!opened) return
-      queueMicrotask(() => editorRef.current?.revealLine(lineNumber))
+
+      if (editorRef.current) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            editorRef.current?.revealLine(lineNumber)
+          })
+        })
+        return
+      }
+
+      pendingRevealLineRef.current = lineNumber
     },
     [openNoteByRelPath],
   )
+
+  useEffect(() => {
+    const pending = pendingRevealLineRef.current
+    if (pending == null || !activeRelPath) return
+    pendingRevealLineRef.current = null
+    editorRef.current?.revealLine(pending)
+  }, [activeRelPath])
 
   const onTagNoteClick = useCallback(
     async (relPath: string, lineNumber: number | null) => {


### PR DESCRIPTION
## Summary
Fixes task navigation when no note is currently open.

## Root cause
After opening a note from the Tasks sidebar, reveal was scheduled in a microtask. If `NoteEditor` was not mounted yet, `editorRef.current` was null and reveal was lost.

## What changed
- Added `pendingRevealLineRef` in `App.tsx`.
- Updated `onTaskClick`:
  - if editor is mounted: reveal after double `requestAnimationFrame`.
  - if editor is not mounted: store line in `pendingRevealLineRef`.
- Added `useEffect([activeRelPath])` to consume pending reveal after note switch/mount.

## Result
- First click from Tasks panel now reliably opens and reveals the intended task line, even from empty/start state.

Closes #99
