### PR TITLE
feat(mobile): ship mobile web shell groundwork

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#14161a" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Draglass" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <title>draglass</title>
   </head>
   <body>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Draglass",
+  "short_name": "Draglass",
+  "description": "Local-first, privacy-first Markdown knowledge base",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#14161a",
+  "theme_color": "#14161a",
+  "icons": [
+    {
+      "src": "/vite.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/src/index.css
+++ b/src/index.css
@@ -118,6 +118,12 @@ body {
 
 #root {
   height: 100vh;
+  height: 100dvh;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  box-sizing: border-box;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
Smallest shippable first slice for #95 (mobile app): add mobile web-app shell metadata and safe-area handling.

## Scope (this PR)
- Add `public/manifest.webmanifest` so Draglass can run as a standalone web app shell.
- Add mobile meta tags in `index.html` (`viewport-fit=cover`, theme color, Apple mobile-web-app tags, manifest link).
- Add safe-area inset padding in `#root` (`env(safe-area-inset-*)`) to avoid notch/home-indicator overlap on mobile devices.

## Why this slice
This is a low-risk, immediate foundation step toward iPad/mobile use while keeping PR scope small and shippable.

## Validation
- Full test suite passes locally (`npm test`).

Part of #95
